### PR TITLE
fix issue with belongs_to ids being included in the searchable attributes

### DIFF
--- a/.changelog_entries/1d952700c037533909615648b5f10582.json
+++ b/.changelog_entries/1d952700c037533909615648b5f10582.json
@@ -1,0 +1,1 @@
+{"type":"Documented","tickets":[],"description":"README: improved example code.","tags":[]}

--- a/.changelog_entries/config.json
+++ b/.changelog_entries/config.json
@@ -1,0 +1,1 @@
+{"git_add":true}

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ You can override these methods if needed, but you're unlikely to want to.
 
 Assuming you've done the above a new index will be created with a name that
 corresponds to your model's  name, only in snake case. All of your models
-attributes will be indexed and [filterable](https://www.meilisearch.com/docs/learn/fine_tuning_results/filtering).
+fields will be indexed and [filterable](https://www.meilisearch.com/docs/learn/fine_tuning_results/filtering).
+
 
 ### Example Rails Model
 
@@ -104,6 +105,9 @@ class Person
 end
 ```
 
+Note that that _unless you configure it otherwise_ the ids of `belongs_to` objects 
+will not be searchable. This is because they're random strings that no human's ever
+going to be searching for, and we don't want to waste RAM or storage.
 
 ### Going Beyond The Defaults 
 This module strives for sensible defaults, but you can override them with the
@@ -163,7 +167,7 @@ as `original_document_id`. This is useful if you want to be able to retrieve the
 You probably don't want to index _all_ the fields. For example, 
 unless you intend to allow users to sort by when a record was created, 
 there's no point in recording it's `created_at` in the search index. 
-It'll just waste bandwidth, memory, and disk space.
+It'll just waste bandwidth, memory, and disk space. 
 
 Define a `SEARCHABLE_ATTRIBUTES` constant with an array of strings to limit things. 
 By default these will _also_ be the fields you can filter on. Note that 
@@ -179,6 +183,15 @@ document's `BSON::ObjectId`.
   SEARCHABLE_ATTRIBUTES = searchable_attributes - [:created_at]
 ```
 
+#### Including Foreign Key data
+If, for example, your `Person` `belongs_to: group` 
+and you wanted that group's id to be searchable you would include `group_id`
+in the list. 
+
+If you don't specify any `SEARCHABLE_ATTRIBUTES`, the default list will
+exclude any fields that are `Mongoid::Fields::ForeignKey` objects.
+
+
 #### Getting Extra Specific
 If your searchable data needs to by dynamically generated instead of 
 just taken directly from the `Mongoid::Document`'s attributes you can
@@ -187,8 +200,8 @@ must return a hash, and that hash must include the following keys:
 - `"id"` - a string that uniquely identifies the record
 - `"object_class"` the name of the class that this record corresponds to.
 
-The value of `"object_class"` is usually just `self.class.name`. Additionally,
-this is something specific to this gem, and not Meilisearch itself.
+The value of `"object_class"` is usually just `self.class.name`. 
+This is something specific to this gem, and not Meilisearch itself.
 
 See `InstanceMethods#search_indexable_hash` for an example. 
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+# <!-- :TOC: -->
+- [MongodbMeilisearch](#mongodbmeilisearch)
+  - [Installation](#installation)
+  - [Usage](#usage)
+  - [Model Integration](#model-integration)
+  - [Indexes](#indexes)
+  - [Searching](#searching)
+  - [Development](#development)
+  - [License](#license)
+  - [Code of Conduct](#code-of-conduct)
+
 # MongodbMeilisearch
 
 A simple gem for integrating [Meilisearch](https://www.meilisearch.com) into Ruby† applications that are backed by [MongoDB](https://www.mongodb.com/).
@@ -35,7 +46,10 @@ SEARCH_ENABLED=true
 MEILISEARCH_API_KEY=<your api key here>
 MEILISEARCH_URL=http://127.0.0.1:7700
 
-# optional configuration
+```
+
+Optional configuration
+```bash
 MEILISEARCH_TIMEOUT=10
 MEILISEARCH_MAX_RETRIES=2
 ```
@@ -46,8 +60,8 @@ Add the following near the top of your model. Only the `extend` and `include` li
 This assumes your model also includes `Mongoid::Document`
 
 ```ruby
-  extend Search::ClassMethods
   include Search::InstanceMethods
+  extend Search::ClassMethods
 ```
 
 If you want Rails to automatically add, update, and delete records from the index, add the following to your model. 
@@ -67,17 +81,40 @@ Assuming you've done the above a new index will be created with a name that
 corresponds to your model's  name, only in snake case. All of your models
 attributes will be indexed and [filterable](https://www.meilisearch.com/docs/learn/fine_tuning_results/filtering).
 
+### Example Rails Model
+
+Here's what it looks like when you put it all 
+together in a Rails model with the default behavior.
+
+```ruby
+class Person
+  include Mongoid::Document
+  extend Search::ClassMethods
+
+  if Search::Client.instance.enabled?
+    after_create  :add_to_search
+    after_update  :update_in_search
+    after_destroy :remove_from_search
+  end
+
+  # normal Mongoid attributes
+  field :name, type: String
+  field :description, type: String
+  field :age, type: Integer
+end
+```
+
 
 ### Going Beyond The Defaults 
 This module strives for sensible defaults, but you can override them with the
 following optional constants:
 
-* `PRIMARY_SEARCH_KEY` - a Symbol matching one of your model's attributes 
+- `PRIMARY_SEARCH_KEY` - a Symbol matching one of your model's attributes 
   that is guaranteed unique. This defaults to `_id`
-* `SEARCH_INDEX_NAME` - a String - useful if you want to have records from
+- `SEARCH_INDEX_NAME` - a String - useful if you want to have records from
   multiple classes come back in the same search results. This defaults to the
   underscored form of the current class name.
-* `SEARCH_OPTIONS` - a hash of key value pairs in JS style
+- `SEARCH_OPTIONS` - a hash of key value pairs in JS style
     - See  the [meilisearch search parameter docs](https://www.meilisearch.com/docs/reference/api/search#search-parameters) for details.
     - example from [meliesearch's `multi_param_spec`](https://github.com/meilisearch/meilisearch-ruby/blob/main/spec/meilisearch/index/search/multi_params_spec.rb)
   ```ruby
@@ -89,7 +126,7 @@ following optional constants:
         limit: 2
       }
     ```
-* `SEARCH_RANKING_RULES` - an array of strings that correspond to meilisearch rules
+- `SEARCH_RANKING_RULES` - an array of strings that correspond to meilisearch rules
   see [meilisearch ranking rules docs](https://www.meilisearch.com/docs/learn/core_concepts/relevancy#ranking-rules)
 You probably don't want to change this.
 
@@ -200,7 +237,12 @@ is potentially problematic for your users, and thus noted with a bang.
 For example: 
 ```ruby
 MyModel.reindex  # runs asyncronously
-# vs 
+
+```
+
+vs 
+
+```ruby
 MyModel.reindex! # runs synchronously
 ```
 
@@ -303,8 +345,7 @@ E.g. `MyModel.search("search term", include_metadata: false)`
 Search results, ids only, for a class where `CLASS_PREFIXED_SEARCH_IDS=false`. 
 
 ```ruby
-Note.search('foo', ids_only: true)
-# returns 
+Note.search('foo', ids_only: true) # => returns 
 { 
   "matches" =>  [
     "64274a5d906b1d7d02c1fcc7",
@@ -328,8 +369,7 @@ Without `ids_only` you get full objects in a `matches` array.
 
 
 ```ruby
-Note.search('foo') # or Note.search('foo', ids_only: false)
-# returns 
+Note.search('foo') # or Note.search('foo', ids_only: false) # => returns 
 { 
   "matches" => [
     #<Note _id: 64274a5d906b1d7d02c1fcc7, created_at: 2023-03-15 00:00:00 UTC, updated_at: 2023-03-31 21:02:21.108 UTC, title: "A note from the past", body: "a body", type: "misc", context: "dachary">,
@@ -348,8 +388,7 @@ Note.search('foo') # or Note.search('foo', ids_only: false)
 If `Note` records shared an index with `Task` and they both had `CLASS_PREFIXED_SEARCH_ID=true` you'd get a result like this.
 
 ```ruby
-Note.search('foo')
-# returns 
+Note.search('foo') #=> returns 
 { 
   "matches" => [
       #<Note _id: 64274a5d906b1d7d02c1fcc7, created_at: 2023-03-15 00:00:00 UTC, updated_at: 2023-03-31 21:02:21.108 UTC, title: "A note from the past", body: "a body", type: "misc", context: "dachary">,

--- a/lib/search/class_methods.rb
+++ b/lib/search/class_methods.rb
@@ -339,7 +339,12 @@ module Search
     # Please don't override this. Define SEARCHABLE_ATTRIBUTES instead.
     # @return [Array[Symbol]] an array of attribute names as symbols
     def default_searchable_attributes
-      attribute_names.map { |n| n.to_sym }
+      good_fields = []
+      fields.each { |name, obj|
+        next if name == "_type"
+        good_fields.push(name.to_sym) unless obj.is_a? Mongoid::Fields::ForeignKey
+      }
+      good_fields
     end
 
     # This returns the list from SEARCHABLE_ATTRIBUTES if defined,

--- a/spec/search/class_methods_spec.rb
+++ b/spec/search/class_methods_spec.rb
@@ -35,6 +35,12 @@ RSpec.describe Search::ClassMethods do
       )
     end
 
+    it "does not include foreign keys in default searchable attributes" do
+      expect(BasicTestModel.searchable_attributes).to(
+        match_array(%i[_id name description age])
+      )
+    end
+
     context "with class filtered search options" do
       let!(:class_filter_string) { "object_class = BasicTestModel" }
 

--- a/spec/test_classes.rb
+++ b/spec/test_classes.rb
@@ -8,6 +8,17 @@ class BasicTestModel
   field :name, type: String
   field :description, type: String
   field :age, type: Integer
+
+  has_many :related_models
+  belongs_to :related_model
+end
+
+class RelatedModel
+  include Mongoid::Document
+  include Search::InstanceMethods
+  extend Search::ClassMethods
+  field :name, type: String
+  has_many :basic_test_models
 end
 
 class UnfilterableTestModel < BasicTestModel


### PR DESCRIPTION
This Fixes Issue #2	

If you really want to you _can_ specify the inclusion of relation ids by adding `field_name_id` to your `SEARCHABLE_ATTRIBUTES` but it will result in a BSON object being indexed instead of just the string value of the ID. 

If you want the string you'll have to make a custom `search_indexable_hash` function on your model. 