### PR TITLE
attempting to address CI failures

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,8 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.3-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.15.3-x86_64-linux)
+      racc (~> 1.4)
     parallel (1.23.0)
     parser (3.2.2.3)
       ast (~> 2.4.1)
@@ -220,6 +222,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   debug

--- a/lib/search/client.rb
+++ b/lib/search/client.rb
@@ -13,8 +13,8 @@ module Search
         max_retries = ENV.fetch("MEILISEARCH_MAX_RETRIES", 2).to_i
         if url.present? && api_key.present?
           @client = MeiliSearch::Client.new(url, api_key,
-            timeout: timeout,
-            max_retries: max_retries)
+                                            timeout: timeout,
+                                            max_retries: max_retries)
         else
           Rails.logger.warn("UNABLE TO CONFIGURE SEARCH. Check env vars.")
           @client = nil


### PR DESCRIPTION
ran the following as per the error's instructions and commited the result.

```
bundle lock --add-platform x86_64-linux
```

made rubocop happy with `search/client.rb`